### PR TITLE
Bugfix#1 massimo_runtime.py

### DIFF
--- a/massimo/plug-ins/massimo_runtime.py
+++ b/massimo/plug-ins/massimo_runtime.py
@@ -675,12 +675,8 @@ class CenterOfMassDrawOverride(OpenMayaRender.MPxDrawOverride):
 
         if data.drawVerticalLine:
             drawManager.line(
-                OpenMaya.MPoint(
-                    *data.floor,
-                ),
-                OpenMaya.MPoint(
-                    *data.ceil,
-                )
+                OpenMaya.MPoint(*data.floor),
+                OpenMaya.MPoint(*data.ceil),
             )
 
         drawManager.endDrawable()


### PR DESCRIPTION
Bugfix #1
Removed trailing commas on unpacked args causing a syntax error.